### PR TITLE
fix: Prisma Engine が Vercel 本番で見つからない問題の修正 (#12)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -6,6 +6,15 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  experimental: {
+    // Vercel のファイルトレースに Prisma のバイナリを必ず含める
+    outputFileTracingIncludes: {
+      // app/api 以下で使う場合
+      '/api/**': ['./node_modules/.prisma/client/**/*'],
+      // 念のためその他ルートでも Prisma を使う可能性がある場合
+      '/*': ['./node_modules/.prisma/client/**/*'],
+    },
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## 概要

Issue #12 の対応です。  
Vercel 本番環境で Prisma Client の Query Engine が見つからず、OCR 後の保存処理が失敗していた問題を修正しました。

## 変更内容

- `next.config.mjs` に `experimental.outputFileTracingIncludes` を追加し、Prisma のバイナリをデプロイ成果物に含めるように修正

```js
/** @type {import('next').NextConfig} */
const nextConfig = {
  typescript: {
    ignoreBuildErrors: true,
  },
  images: {
    unoptimized: true,
  },
  experimental: {
    outputFileTracingIncludes: {
      "/api/**": ["./node_modules/.prisma/client/**/*"],
      "/*": ["./node_modules/.prisma/client/**/*"],
    },
  },
}

export default nextConfig
```
## 動作確認
- ローカルで npx prisma generate を実行し、エラーが出ないことを確認
-  ブランチをデプロイ後、レシート画像をアップロード
- 解析結果が DB に保存され、画面上に表示されることを確認
- Prisma Engine のエラーがログに出ていないことを確認