### PR TITLE
feat: OCRレシート画像の保存とプレビュー対応 #14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@supabase/supabase-js": "^2.80.0",
         "@vercel/analytics": "latest",
         "autoprefixer": "^10.4.20",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "1.0.4",
@@ -6503,6 +6504,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.27.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.27.0.tgz",
@@ -10635,6 +10645,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
       "license": "MIT"
     },
     "node_modules/victory-vendor": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@supabase/supabase-js": "^2.80.0",
     "@vercel/analytics": "latest",
     "autoprefixer": "^10.4.20",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "1.0.4",

--- a/src/app/api/ocr/route.ts
+++ b/src/app/api/ocr/route.ts
@@ -2,6 +2,7 @@
 import { NextResponse } from "next/server"
 import sharp from "sharp"
 import { ImageAnnotatorClient, protos as visionProtos } from "@google-cloud/vision"
+import { createSupabaseServerClientReadonly } from "@/lib/supabase/server"
 
 export const runtime = "nodejs"
 
@@ -9,6 +10,7 @@ export const runtime = "nodejs"
 const MAX_FILE_BYTES = 10 * 1024 * 1024 // 10MB
 const ALLOWED_MIME = new Set(["image/jpeg", "image/png", "image/jpg"])
 const DEFAULT_MODE = "text" as const // "text" | "document"
+const RECEIPT_BUCKET = "receipts" // Supabase Storage のバケット名（作成しておく）
 
 // ---- 型エイリアス ----
 type AnnotateResponse = visionProtos.google.cloud.vision.v1.IAnnotateImageResponse
@@ -17,8 +19,11 @@ type Block = visionProtos.google.cloud.vision.v1.IBlock
 type Vertex = visionProtos.google.cloud.vision.v1.IVertex
 
 // ---- ヘルパー ----
-function bad(status: number, message: string) {
-  return NextResponse.json({ error: message }, { status })
+function bad(status: number, message: string, detail?: unknown) {
+  return NextResponse.json(
+    detail ? { error: message, detail } : { error: message },
+    { status },
+  )
 }
 
 /** ローカル(JSONキー) or Vercel(環境変数) 両対応クライアント */
@@ -114,7 +119,6 @@ function findAmountAfterKeyword(lines: string[], keywords: RegExp[]): number | u
 
 // ==== 店名スコアリング関連ヘルパー ====
 
-// 店名には使いたくないワード
 const STORE_STOP_WORDS =
   /(領収書|レシート|電話|TEL|住所|〒|伝票番号|レジ|#\d+|事業者登録番号|登録番号)/
 
@@ -153,18 +157,14 @@ function scoreStoreLikeLine(line: string): number {
 }
 
 // 店名抽出：ブランド名ハードコードではなく「店名っぽさスコア」で決める
-// 店名抽出：ブランド名ハードコードではなく「店名っぽさスコア」で決める
 function extractStoreName(lines: string[], fullText: string): string {
-  // ★ ヘッダー行を「先頭から STOP_WORD に当たるまで」で切り出す
   const headerLines: string[] = []
   for (const line of lines) {
-    // 領収書 / 電話 / 事業者登録番号 などが出てきたらヘッダー終わり
     if (STORE_STOP_WORDS.test(line)) break
     headerLines.push(line)
-    if (headerLines.length >= 12) break // 念のための上限
+    if (headerLines.length >= 12) break
   }
 
-  // スコア付き候補リストを作成
   const scored = headerLines
     .map((line, idx) => ({
       line,
@@ -175,10 +175,9 @@ function extractStoreName(lines: string[], fullText: string): string {
     .sort((a, b) => b.score - a.score)
 
   if (scored.length === 0) {
-    // どうしても候補がない場合は、STOP_WORD などを除いた最初の行をフォールバックに
     const fallback =
       headerLines.find(
-        (l) => !STORE_STOP_WORDS.test(l) && !isAddressLine(l) && /[^\d\W]/u.test(l), // 何かしら文字を含む
+        (l) => !STORE_STOP_WORDS.test(l) && !isAddressLine(l) && /[^\d\W]/u.test(l),
       ) ||
       lines[0] ||
       ""
@@ -188,7 +187,7 @@ function extractStoreName(lines: string[], fullText: string): string {
   const best = scored[0]
   let name = best.line
 
-  // 直前の行がブランド名っぽいならくっつける（例：LAWSON + 大阪〇〇店）
+  // 直前の行がブランド名っぽいならくっつける
   if (best.idx > 0) {
     const prev = headerLines[best.idx - 1]
     if (
@@ -202,7 +201,6 @@ function extractStoreName(lines: string[], fullText: string): string {
     }
   }
 
-  // 明らかに崩れやすいブランドだけ軽く補正する辞書（現時点のアイデア）
   const BRAND_NORMALIZERS: { pattern: RegExp; canonical: string }[] = [
     { pattern: /SEVEN.?ELEVEN/i, canonical: "セブン-イレブン" },
     { pattern: /STAR.?BUCKS/i, canonical: "スターバックス" },
@@ -210,7 +208,6 @@ function extractStoreName(lines: string[], fullText: string): string {
 
   for (const b of BRAND_NORMALIZERS) {
     if (b.pattern.test(fullText)) {
-      // 例: "SEVENL1IDOLINOs 大阪西今川1丁目店" → "セブン-イレブン 大阪西今川1丁目店"
       if (/店$/.test(name)) {
         const parts = name.split(/\s+/)
         const branch = parts.slice(1).join(" ")
@@ -225,28 +222,23 @@ function extractStoreName(lines: string[], fullText: string): string {
 
 /** レシート向け抽出（店名/日付/合計/税） 改良版 */
 function extractReceiptFields(text: string) {
-  // 行へ分割→正規化
   const lines = text
     .split(/\r?\n/)
     .map((s) => normalize(s))
     .filter(Boolean)
 
-  // ---- 店名 ----
   const storeName = extractStoreName(lines, text)
 
   // ---- 合計金額 ----
-  // まず「総合計 / 合計金額 / お会計 / TOTAL」を優先
   const primaryTotalKeywords = [/総合計/, /合計金額/, /お会計/, /TOTAL/i]
   let total = findAmountAfterKeyword(lines, primaryTotalKeywords)
 
-  // それでも見つからなければ、汎用的な「合計 / 合算」で探す
   if (total == null) {
     const secondaryTotalKeywords = [/合計/, /合算/]
     total = findAmountAfterKeyword(lines, secondaryTotalKeywords)
   }
 
   if (total == null) {
-    // ¥付き最大値を合計と推定（フォールバック）
     const yenAmounts = lines
       .flatMap((l) => [...l.matchAll(/¥\s*([０-９0-9]{1,3}(?:[,\s][０-９0-9]{3})*|[０-９0-9]+)/g)])
       .map((m) => parseAmount(m[1]))
@@ -260,9 +252,8 @@ function extractReceiptFields(text: string) {
   for (let i = 0; i < lines.length; i++) {
     const l = lines[i]
     if (taxKeywords.some((r) => r.test(l))) {
-      if (/%/.test(l)) continue // 8%/10% などはスキップ
+      if (/%/.test(l)) continue
 
-      // この行と次行からすべての数値を抽出
       let candidates = findNumericAmounts(l)
       const next = lines[i + 1]
       if (next && !/%/.test(next)) {
@@ -270,14 +261,13 @@ function extractReceiptFields(text: string) {
       }
 
       if (candidates.length) {
-        // 一番小さい値を税額として採用（多くのレシートで妥当）
         tax = Math.min(...candidates)
         break
       }
     }
   }
 
-  // ---- 日付（2025-10-28 / 2025/10/28 / 2025.10.28 / 2025年10月28日）----
+  // ---- 日付 ----
   let purchaseDate = ""
   {
     const m = lines
@@ -297,27 +287,83 @@ function extractReceiptFields(text: string) {
 // ---- メイン処理 ----
 export async function POST(req: Request) {
   try {
+    // まずは認証ユーザーを取得
+    const supabase = await createSupabaseServerClientReadonly()
+    const { data: authData, error: authError } = await supabase.auth.getUser()
+    if (authError || !authData?.user) {
+      console.error("[/api/ocr] auth error:", authError)
+      return bad(401, "unauthorized", authError?.message)
+    }
+    const supabaseUser = authData.user
+
     const ct = req.headers.get("content-type") || ""
     if (!ct.includes("multipart/form-data"))
       return bad(415, "content-type must be multipart/form-data")
 
     const form = await req.formData()
-    const file = form.get("file") as File | null
-    if (!file) return bad(400, "file is required")
+    const fileEntry = form.get("file")
+
+    // ここで File 型に絞り込む（any 不要＆実行時にも安全）
+    if (!(fileEntry instanceof File)) {
+      return bad(400, "file is required")
+    }
+    const file = fileEntry
+
     if (!ALLOWED_MIME.has(file.type)) return bad(400, "unsupported file type")
     if (file.size > MAX_FILE_BYTES) return bad(400, "file too large (max 10MB)")
 
+    console.log("[/api/ocr] incoming file:", {
+      name: file.name,
+      type: file.type,
+      size: file.size,
+    })
+
     const url = new URL(req.url)
-    const mode = (url.searchParams.get("mode") || DEFAULT_MODE) as "text" | "document"
+    const modeParam = url.searchParams.get("mode") || DEFAULT_MODE
+    const mode = (modeParam === "document" ? "document" : "text") as "text" | "document"
 
     // 画像前処理：傾き補正 + グレースケール + 軽量化 + PNG化
     const buf = Buffer.from(await file.arrayBuffer())
+    console.log("[/api/ocr] original buffer size (bytes):", buf.length)
+
     const preprocessed = await sharp(buf)
       .rotate()
       .grayscale()
       .resize({ width: 1600, withoutEnlargement: true })
       .toFormat("png")
       .toBuffer()
+
+    console.log("[/api/ocr] preprocessed buffer size (bytes):", preprocessed.length)
+
+    // Supabase Storage に保存（ユーザーごとにパスを分ける）
+    const timestamp = Date.now()
+    const storagePath = `${supabaseUser.id}/${timestamp}.png`
+
+    const { error: uploadError } = await supabase.storage
+      .from(RECEIPT_BUCKET)
+      .upload(storagePath, preprocessed, {
+        contentType: "image/png",
+        upsert: false,
+      })
+
+    if (uploadError) {
+      console.error("[/api/ocr] storage upload error:", uploadError)
+      return bad(
+        500,
+        "image upload failed",
+        uploadError.message ??
+          // @ts-expect-error supabase error 型によっては error / status などがある
+          uploadError.error ??
+          String(uploadError),
+      )
+    }
+
+    const {
+      data: { publicUrl },
+    } = supabase.storage.from(RECEIPT_BUCKET).getPublicUrl(storagePath)
+
+    // URL表示
+    console.log("[/api/ocr] publicUrl:", publicUrl)
 
     const client = createVisionClient()
     const image = { content: preprocessed }
@@ -331,7 +377,6 @@ export async function POST(req: Request) {
     const text = result.fullTextAnnotation?.text?.trim() || ""
     const confidence = estimateConfidence(result)
 
-    // ブロック単位の簡易レイアウト（座標 + 文字列）
     const pages = (result.fullTextAnnotation?.pages ?? []) as Page[]
     const blocks = pages.flatMap((p: Page) =>
       (p.blocks ?? []).map((b: Block) => ({
@@ -350,11 +395,24 @@ export async function POST(req: Request) {
     const extracted = extractReceiptFields(text)
 
     console.log("[/api/ocr] extracted:", extracted)
-    console.log("[/api/ocr] raw text:", text)
+    console.log("[/api/ocr] raw text length:", text.length)
+    console.log("[/api/ocr] image stored at:", storagePath)
 
-    return NextResponse.json({ text, confidence, blocks, extracted, mode })
+    return NextResponse.json({
+      text,
+      confidence,
+      blocks,
+      extracted,
+      mode,
+      image: {
+        path: storagePath,
+        url: publicUrl,
+      },
+    })
   } catch (e) {
     console.error("[/api/ocr] Vision error:", e)
-    return bad(500, "Vision API failed")
+    const detail =
+      e instanceof Error ? e.message : typeof e === "string" ? e : JSON.stringify(e)
+    return bad(500, "Vision API failed", detail)
   }
 }

--- a/src/app/api/receipts/[id]/route.ts
+++ b/src/app/api/receipts/[id]/route.ts
@@ -4,6 +4,7 @@ import type { Prisma } from "@prisma/client"
 import { prisma } from "@/lib/prisma"
 import { getUserIdFromSession } from "@/app/api/_auth-helpers"
 import type { Receipt } from "@/types/receipt"
+import { createSupabaseServiceClient } from "@/lib/supabase/server"
 
 function getErrorMessage(err: unknown): string {
   if (err instanceof Error) return err.message
@@ -25,7 +26,9 @@ type DbReceiptWithRelations = Prisma.ReceiptGetPayload<{
 
 // DB のレシート + items + files をフロント用の Receipt 型に変換
 function mapDbReceiptToReceipt(dbReceipt: DbReceiptWithRelations): Receipt {
-  const imageUrl = dbReceipt.imageUrl ?? dbReceipt.files?.[0]?.url ?? undefined
+  // files[0].url を優先、なければ imageUrl を使う
+  const primaryFile = dbReceipt.files?.[0]
+  const imageUrl = primaryFile?.url ?? dbReceipt.imageUrl ?? undefined
 
   return {
     id: dbReceipt.id,
@@ -45,6 +48,8 @@ function mapDbReceiptToReceipt(dbReceipt: DbReceiptWithRelations): Receipt {
     status: dbReceipt.status,
     confidenceScore: dbReceipt.confidenceScore ?? undefined,
     imageUrl,
+
+    // 品目一覧
     items: dbReceipt.items.map((item) => ({
       id: item.id,
       name: item.name,
@@ -52,6 +57,28 @@ function mapDbReceiptToReceipt(dbReceipt: DbReceiptWithRelations): Receipt {
       unitPrice: item.unitPrice != null ? Number(item.unitPrice) : 0,
       amount: item.amount != null ? Number(item.amount) : 0,
     })),
+
+    // 添付ファイル一覧（Supabase Storage の画像など）
+    files:
+      dbReceipt.files?.map((f) => ({
+        id: f.id,
+        receiptId: f.receiptId,
+        page: f.page,
+        url: f.url,
+        mimeType: f.mimeType,
+        width: f.width,
+        height: f.height,
+        sha256: f.sha256,
+        createdAt:
+          f.createdAt instanceof Date
+            ? f.createdAt.toISOString()
+            : (f.createdAt as unknown as string),
+        updatedAt:
+          f.updatedAt instanceof Date
+            ? f.updatedAt.toISOString()
+            : (f.updatedAt as unknown as string),
+      })) ?? [],
+
     categoryId: dbReceipt.categoryId ?? undefined,
     createdAt:
       dbReceipt.createdAt instanceof Date
@@ -95,8 +122,22 @@ export async function GET(
       },
       include: {
         items: true,
-        files: true,
+        files: {
+          // 1ページ目から順に並べる
+          orderBy: { page: "asc" },
+        },
       },
+    })
+
+    // 必要ならログを残してデバッグ
+    console.log("[GET /api/receipts/[id]] dbReceipt:", {
+      id: dbReceipt?.id,
+      imageUrl: dbReceipt?.imageUrl,
+      files: dbReceipt?.files?.map((f) => ({
+        id: f.id,
+        url: f.url,
+        mimeType: f.mimeType,
+      })),
     })
 
     if (!dbReceipt) {
@@ -181,7 +222,6 @@ export async function PUT(
             quantity: item.quantity,
             unitPrice: item.unitPrice ?? 0,
             amount: item.amount ?? 0,
-            // Decimal → number に変換してから渡す
             taxRate:
               existing.taxRate != null ? Number(existing.taxRate) : null,
             rawLine: null,
@@ -198,7 +238,9 @@ export async function PUT(
         },
         include: {
           items: true,
-          files: true,
+          files: {
+            orderBy: { page: "asc" },
+          },
         },
       })
 
@@ -219,5 +261,88 @@ export async function PUT(
     }
 
     return NextResponse.json({ ok: false, error: getErrorMessage(err) }, { status: 500 })
+  }
+}
+
+// ===== ここから DELETE: レシート削除 + Supabase Storage 画像削除 =====
+
+export async function DELETE(
+  _req: NextRequest,
+  context: { params: Promise<{ id: string }> },
+) {
+  try {
+    const userId = await getUserIdFromSession()
+    if (!userId) {
+      return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 })
+    }
+
+    const { id } = await context.params
+
+    // 1) 自分のレシートか確認しつつ、紐づく files を取得
+    const receipt = await prisma.receipt.findFirst({
+      where: {
+        id,
+        userId,
+        deletedAt: null,
+      },
+      include: {
+        files: true,
+      },
+    })
+
+    if (!receipt) {
+      return NextResponse.json({ ok: false, error: "not found" }, { status: 404 })
+    }
+
+    // 2) Storage の key を URL から抽出
+    //    Supabase の public URL は
+    //    https://<project>.supabase.co/storage/v1/object/public/receipts/<path>
+    //    という形なので、`/receipts/` 以降を key とする
+    const storageKeys = receipt.files
+      .map((f) => {
+        try {
+          const url = new URL(f.url)
+          const marker = "/receipts/"
+          const idx = url.pathname.indexOf(marker)
+          if (idx === -1) return null
+          // 例: "<user-id>/1234567890.png"
+          return url.pathname.slice(idx + marker.length)
+        } catch {
+          return null
+        }
+      })
+      .filter((k): k is string => !!k)
+
+    // 3) DB のレシート削除（ReceiptFile は ON DELETE CASCADE で一緒に削除される想定）
+    await prisma.receipt.delete({
+      where: { id: receipt.id },
+    })
+
+    // 4) Supabase Storage からも画像削除（ベストエフォート）
+    if (storageKeys.length > 0) {
+      try {
+        const supabase = createSupabaseServiceClient()
+        const { error: storageError } = await supabase.storage
+          .from("receipts")
+          .remove(storageKeys)
+
+        if (storageError) {
+          console.error(
+            "[DELETE /api/receipts/[id]] storage remove error:",
+            storageError,
+          )
+        }
+      } catch (e) {
+        console.error("[DELETE /api/receipts/[id]] storage remove thrown:", e)
+      }
+    }
+
+    return NextResponse.json({ ok: true })
+  } catch (err) {
+    console.error("[DELETE /api/receipts/[id]] error:", err)
+    return NextResponse.json(
+      { ok: false, error: getErrorMessage(err) },
+      { status: 500 },
+    )
   }
 }

--- a/src/app/api/receipts/import/route.ts
+++ b/src/app/api/receipts/import/route.ts
@@ -4,7 +4,16 @@ import { persistReceipt } from "@/server/receipts/persist"
 import { getUserIdFromSession } from "@/app/api/_auth-helpers"
 import { parseOcrToReceipt } from "@/lib/parseOcrToReceipt"
 import type { PersistInput } from "@/server/receipts/persist"
-import type { ReceiptItem } from "@/components/receipt/types"
+
+// ---- ここからこのファイル専用の型 ----
+
+type ParsedItem = {
+  name: string
+  qty: number
+  unitPrice: number
+  total: number
+  taxRate?: number | undefined
+}
 
 type ImportFile = {
   url: string
@@ -15,14 +24,22 @@ type ImportFile = {
   page?: number
 }
 
-// ScanContent から渡ってくるサマリ用
+// OCR API (/api/ocr) から直接渡される単一画像想定
+type ImportImage = {
+  url: string
+  mimeType?: string
+  width?: number
+  height?: number
+  sha256?: string
+  page?: number
+}
+
 type ExtractedSummary = {
   storeName?: string | null
   purchaseDate?: string | null
   total?: number | null
 }
 
-// parseOcrToReceipt の戻り値に items 情報を足して扱うための緩い型
 type NormalizedReceipt = ReturnType<typeof parseOcrToReceipt> & {
   merchant?: { name?: string | null } | null
   purchasedAt?: string | null
@@ -30,12 +47,13 @@ type NormalizedReceipt = ReturnType<typeof parseOcrToReceipt> & {
     grandTotal?: number | null
     [key: string]: unknown
   }
-  items?: ReceiptItem[]
+  items?: ParsedItem[]
 }
 
 type ImportBody = {
   rawOcrText: string
   files?: ImportFile[]
+  image?: ImportImage | null
   parser?: string
   parseVersion?: string
   ocrEngine?: PersistInput["ocrEngine"]
@@ -64,6 +82,7 @@ export async function POST(req: Request) {
     const {
       rawOcrText,
       files,
+      image,
       parser,
       parseVersion,
       ocrEngine = "OTHER",
@@ -75,12 +94,31 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "rawOcrText is required" }, { status: 400 })
     }
 
+    // ========== 画像ファイル情報を正規化 ==========
+    let normalizedFiles: ImportFile[] | undefined
+
+    if (files && files.length > 0) {
+      normalizedFiles = files
+    } else if (image && image.url) {
+      normalizedFiles = [
+        {
+          url: image.url,
+          mimeType: image.mimeType ?? "image/png",
+          width: image.width,
+          height: image.height,
+          sha256: image.sha256,
+          page: image.page ?? 1,
+        },
+      ]
+    } else {
+      normalizedFiles = undefined
+    }
+
     // 1. まずは既存ロジックで正規化
     let normalized = parseOcrToReceipt(rawOcrText) as NormalizedReceipt
 
     // 2. extracted があれば、足りないところだけ上書きフォールバック
     if (extracted) {
-      // 店名
       const currentName = normalized.merchant?.name
       const shouldOverrideName = !currentName || currentName === "不明な店舗"
 
@@ -94,7 +132,6 @@ export async function POST(req: Request) {
         }
       }
 
-      // 購入日
       if (!normalized.purchasedAt && extracted.purchaseDate) {
         normalized = {
           ...normalized,
@@ -102,7 +139,6 @@ export async function POST(req: Request) {
         }
       }
 
-      // 合計金額
       const currentTotal = normalized.totals.grandTotal
       const shouldOverrideTotal = !currentTotal || Number(currentTotal) === 0
 
@@ -124,7 +160,7 @@ export async function POST(req: Request) {
         typeof normalized.totals.grandTotal === "number"
           ? normalized.totals.grandTotal
           : typeof extracted?.total === "number"
-            ? (extracted.total ?? undefined)
+            ? extracted.total ?? undefined
             : undefined
 
       const parsedItems = extractItemsFromText(rawOcrText, fallbackTotal)
@@ -137,19 +173,24 @@ export async function POST(req: Request) {
       }
     }
 
-    // デバッグログ（何が supabase/DB に保存されるか確認用）
     console.log("[IMPORT] normalized receipt:", JSON.stringify(normalized, null, 2))
+    if (normalizedFiles) {
+      console.log("[IMPORT] files to persist:", JSON.stringify(normalizedFiles, null, 2))
+    } else {
+      console.log("[IMPORT] files to persist: none")
+    }
 
     const saved = await persistReceipt({
       userId,
       normalized,
       rawOcrText,
-      files,
+      files: normalizedFiles,
       parser,
       parseVersion,
       ocrEngine,
       taxBreakdown,
-      status: "DRAFT", // OCR直後はドラフト
+      status: "DRAFT",
+      imageUrl: normalizedFiles?.[0]?.url ?? null, // ★ 追加：Receipt.imageUrl 用
     })
 
     console.log("[IMPORT] saved receipt summary:", {
@@ -170,16 +211,14 @@ export async function POST(req: Request) {
 
 //
 // ===== ここから下は品目抽出用ヘルパー =====
+// （ここはそのままでOK）
 //
-
-// 全角→半角・通貨や空白の正規化（OCR用の簡易版）
 function normalizeText(s: string): string {
   const z2h = (str: string) =>
     str.replace(/[０-９．－，￥]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0xfee0))
   return z2h(s).replace(/￥/g, "¥").replace(/\s+/g, " ").trim()
 }
 
-// 金額文字列を数値へ（¥/カンマ/全角対応）
 function parseAmount(raw?: string | null): number | undefined {
   if (!raw) return
   const s = normalizeText(raw).replace(/[^\d.-]/g, "")
@@ -188,23 +227,22 @@ function parseAmount(raw?: string | null): number | undefined {
   return Number.isFinite(n) ? Math.round(n) : undefined
 }
 
-// ダミー items かどうか判定
-function isDummyItems(items: ReceiptItem[] | undefined): boolean {
+function isDummyItems(items: ParsedItem[] | undefined): boolean {
   if (!items || items.length === 0) return true
   if (items.length > 1) return false
+
   const item = items[0]
   const name = item.name ?? ""
   const total = item.total ?? 0
+
   return name === "不明な品目" || total === 0
 }
 
-// 価格行っぽいか（例: "*200", "¥178", " 330", "¥1,441"）
 function isPriceLine(line: string): boolean {
   const s = line.trim()
   return /^(\*|¥|￥)?\s*[０-９0-9]{1,3}(?:[,\s][０-９0-9]{3})*$/.test(s)
 }
 
-// "@165x 2" のような表記から単価と数量を取る
 function parseUnitAndQty(line: string): { unitPrice?: number; qty?: number } {
   const m = line.match(/@?\s*([０-９0-9]+)\s*[x×]\s*([０-９0-9]+)/)
   if (!m) return {}
@@ -213,24 +251,16 @@ function parseUnitAndQty(line: string): { unitPrice?: number; qty?: number } {
   return { unitPrice, qty }
 }
 
-// 品名候補にスコアを付ける
 function scoreItemName(line: string): number {
   const s = line.trim()
   let score = 0
 
   const len = s.length
   if (len < 2 || len > 25) score -= 10
-
-  // 日本語（漢字・カタカナ・ひらがな）が含まれていれば強く加点
   if (/[一-龠々ァ-ヶーぁ-ん]/.test(s)) score += 40
-
-  // 英字だけの場合は少しだけ加点（チェーン名等を想定）
   if (/[A-Za-z]/.test(s)) score += 10
-
-  // 店名・会社名っぽいものは減点（品目ではない可能性が高い）
   if (/(TEL|電話|株式会社|店$)/.test(s)) score -= 30
 
-  // 完全に英字だけっぽい行は減点（OCR ノイズを想定）
   const dense = s.replace(/\s/g, "")
   const asciiCount = dense.match(/[A-Za-z]/g)?.length ?? 0
   const nonAsciiCount = dense.length - asciiCount
@@ -241,34 +271,24 @@ function scoreItemName(line: string): number {
   return score
 }
 
-// 品名候補行かどうか（数字だらけでない、日本語or英字を含む、合計系ではない）
 function isItemNameCandidate(line: string): boolean {
   const s = line.trim()
   if (!s) return false
-
-  // 明細に紛れた「小計」「合計」「税」などは除外
   if (/(小計|合計|総合計|税|円|JPY|領収書|お買上明細)/.test(s)) return false
-  // 価格行も除外
   if (isPriceLine(s)) return false
-
-  // 何かしらの文字（漢字・カナ・ひらがな・英字）が含まれていなければ NG
   if (!/[A-Za-z一-龠々ァ-ヶーぁ-ん]/.test(s)) return false
-
-  // スコアがプラスのものだけ「品名候補」とみなす
   return scoreItemName(s) > 0
 }
 
-function extractItemsFromText(rawText: string, grandTotal?: number): ReceiptItem[] {
+function extractItemsFromText(rawText: string, grandTotal?: number): ParsedItem[] {
   const lines = rawText
     .split(/\r?\n/)
     .map((s) => normalizeText(s))
     .filter(Boolean)
 
-  // 1. 明細ゾーンの範囲を決める
   let startIdx = 0
   let endIdx = lines.length
 
-  // "領収書" や "お買上明細" の次行からスタート
   for (let i = 0; i < lines.length; i++) {
     if (/領収書|お買上明細/.test(lines[i])) {
       startIdx = i + 1
@@ -276,7 +296,6 @@ function extractItemsFromText(rawText: string, grandTotal?: number): ReceiptItem
     }
   }
 
-  // "小計" や "合計" が出てきたところで終わり
   for (let i = startIdx; i < lines.length; i++) {
     if (/小計|合計|総合計/.test(lines[i])) {
       endIdx = i
@@ -285,19 +304,15 @@ function extractItemsFromText(rawText: string, grandTotal?: number): ReceiptItem
   }
 
   const zone = lines.slice(startIdx, endIdx)
-
-  const items: ReceiptItem[] = []
+  const items: ParsedItem[] = []
 
   for (let i = 0; i < zone.length; i++) {
     const line = zone[i]
-
-    // 価格行でなければスキップ
     if (!isPriceLine(line)) continue
 
     const price = parseAmount(line)
     if (price == null) continue
 
-    // 直前の数行から「品名候補」を集める（最大4行くらいまで遡る）
     const nameCandidates: string[] = []
     const unitQty: { unitPrice?: number; qty?: number } = {}
 
@@ -306,7 +321,6 @@ function extractItemsFromText(rawText: string, grandTotal?: number): ReceiptItem
       if (idx < 0) break
       const prev = zone[idx]
 
-      // 数量・単価行（@165x 2 など）があれば記録
       const uq = parseUnitAndQty(prev)
       if (uq.unitPrice || uq.qty) {
         if (!unitQty.unitPrice && uq.unitPrice) unitQty.unitPrice = uq.unitPrice
@@ -314,25 +328,18 @@ function extractItemsFromText(rawText: string, grandTotal?: number): ReceiptItem
         continue
       }
 
-      // 品名候補なら候補リストに追加
       if (isItemNameCandidate(prev)) {
         nameCandidates.push(prev)
       }
 
-      // 小計・合計っぽいものにぶつかったらそこから先は見ない
       if (/(本体合計|小計|合計|総合計)/.test(prev)) {
         break
       }
     }
 
-    if (!nameCandidates.length) {
-      // 品名候補が見つからない場合はスキップ（フォールバックは後でまとめて考える）
-      continue
-    }
+    if (!nameCandidates.length) continue
 
-    // スコアが最も高い品名を採用
     const bestName = nameCandidates.sort((a, b) => scoreItemName(b) - scoreItemName(a))[0]
-
     const qty = unitQty.qty ?? 1
     const unitPrice = unitQty.unitPrice ?? Math.round(price / qty)
 
@@ -345,7 +352,6 @@ function extractItemsFromText(rawText: string, grandTotal?: number): ReceiptItem
     })
   }
 
-  // それでも 1 件も取れなかった場合のフォールバック
   if (!items.length && grandTotal != null && grandTotal > 0) {
     const fallbackName = zone.find((l) => isItemNameCandidate(l)) || "不明な品目"
 

--- a/src/components/receipts/receipt-detail-content.tsx
+++ b/src/components/receipts/receipt-detail-content.tsx
@@ -28,6 +28,20 @@ interface ReceiptDetailContentProps {
   receiptId: string
 }
 
+// API からのレスポンスでは files が付いてくる前提なので、
+// このコンポーネント内だけの拡張型を定義しておく
+type ReceiptWithFiles = Receipt & {
+  files?: {
+    id?: string
+    url?: string | null
+    page?: number | null
+    mimeType?: string | null
+    width?: number | null
+    height?: number | null
+    sha256?: string | null
+  }[]
+}
+
 // エラーメッセージ整形用ヘルパー
 function getErrorMessage(err: unknown): string {
   if (err instanceof Error) return err.message
@@ -40,7 +54,7 @@ function getErrorMessage(err: unknown): string {
 }
 
 export function ReceiptDetailContent({ receiptId }: ReceiptDetailContentProps) {
-  const [receipt, setReceipt] = useState<Receipt | null>(null)
+  const [receipt, setReceipt] = useState<ReceiptWithFiles | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -68,9 +82,10 @@ export function ReceiptDetailContent({ receiptId }: ReceiptDetailContentProps) {
 
         const data = await res.json()
         // {"ok":true,"receipt":{...}} または 直接 { ... } の両方に対応
-        const loaded: Receipt = (data.receipt ?? data) as Receipt
+        const loaded = (data.receipt ?? data) as ReceiptWithFiles
 
         if (!cancelled) {
+          console.log("[ReceiptDetail] loaded receipt from API:", loaded)
           setReceipt(loaded)
         }
       } catch (err) {
@@ -92,7 +107,7 @@ export function ReceiptDetailContent({ receiptId }: ReceiptDetailContentProps) {
     }
   }, [receiptId])
 
-  // ========= 2. 保存処理（TODO: API 実装に合わせてエンドポイントを調整） =========
+  // ========= 2. 保存処理 =========
   const handleSave = async () => {
     if (!receipt) return
     setIsSaving(true)
@@ -112,7 +127,7 @@ export function ReceiptDetailContent({ receiptId }: ReceiptDetailContentProps) {
       }
 
       const data = await res.json()
-      const updated: Receipt = (data.receipt ?? data) as Receipt
+      const updated = (data.receipt ?? data) as ReceiptWithFiles
 
       setReceipt(updated)
 
@@ -162,7 +177,7 @@ export function ReceiptDetailContent({ receiptId }: ReceiptDetailContentProps) {
   }
 
   // ========= 4. フォームの変更反映 =========
-  const handleFormChange = (updates: Partial<Receipt>) => {
+  const handleFormChange = (updates: Partial<ReceiptWithFiles>) => {
     setReceipt((prev) => (prev ? { ...prev, ...updates } : prev))
   }
 
@@ -250,6 +265,21 @@ export function ReceiptDetailContent({ receiptId }: ReceiptDetailContentProps) {
   // ここまで来たら receipt は存在する前提
   if (!receipt) return null
 
+  // ========= 6. 画像 URL の決定ロジック =========
+  // files の中で最初に url を持っているものを採用
+  const fileUrl = receipt.files?.find((f) => !!f.url)?.url ?? null
+
+  const mainImageUrl =
+    fileUrl ??
+    receipt.imageUrl ??
+    "/paper-receipt.png"
+
+  // ★ デバッグログ（ここが重要）
+  console.log("[ReceiptDetail] receipt.id:", receipt.id)
+  console.log("[ReceiptDetail] files from API:", receipt.files)
+  console.log("[ReceiptDetail] receipt.imageUrl:", receipt.imageUrl)
+  console.log("[ReceiptDetail] chosen mainImageUrl:", mainImageUrl)
+
   return (
     <div className="min-h-screen">
       {/* ヘッダー */}
@@ -313,7 +343,7 @@ export function ReceiptDetailContent({ receiptId }: ReceiptDetailContentProps) {
       <div className="grid gap-6 p-4 md:p-6 lg:grid-cols-2 lg:gap-8">
         {/* 左側: 画像プレビュー */}
         <div className="lg:sticky lg:top-24 lg:h-fit">
-          <ReceiptImagePreview imageUrl={receipt.imageUrl ?? "/paper-receipt.png"} />
+          <ReceiptImagePreview imageUrl={mainImageUrl} />
         </div>
 
         {/* 右側: 編集フォーム */}
@@ -332,7 +362,7 @@ export function ReceiptDetailContent({ receiptId }: ReceiptDetailContentProps) {
 
       {/* 下部固定バー */}
       <div className="fixed bottom-0 left-0 right-0 z-10 border-t border-blue-200 bg-white/95 p-4 backdrop-blur shadow-soft-lg md:left-64">
-        <div className="mx-autoflex max-w-4xl items-center justify-between gap-4">
+        <div className="mx-auto flex max-w-4xl items-center justify-between gap-4">
           <Link href="/receipts" className="hidden md:block">
             <Button variant="outline">キャンセル</Button>
           </Link>

--- a/src/components/receipts/receipt-image-preview.tsx
+++ b/src/components/receipts/receipt-image-preview.tsx
@@ -13,6 +13,7 @@ interface ReceiptImagePreviewProps {
 export function ReceiptImagePreview({ imageUrl }: ReceiptImagePreviewProps) {
   const [rotation, setRotation] = useState(0)
   const [zoom, setZoom] = useState(1)
+  console.log("Rendering ReceiptImagePreview with imageUrl:", imageUrl)
 
   const handleRotate = () => {
     setRotation((prev) => (prev + 90) % 360)

--- a/src/components/scan/scan-content.tsx
+++ b/src/components/scan/scan-content.tsx
@@ -41,6 +41,17 @@ type OcrWithText = OcrResponse & {
   text?: string
 }
 
+// /api/ocr が返してくる image を表す補助型
+type OcrImage = {
+  url?: string | null
+  path?: string | null
+  mimeType?: string | null
+  width?: number | null
+  height?: number | null
+  sha256?: string | null
+  page?: number | null
+}
+
 type ScanStep = "upload" | "processing" | "complete" | "error"
 
 function getErrorMessage(err: unknown): string {
@@ -123,11 +134,29 @@ export function ScanContent() {
         // 1. OCR 実行
         const ocr = await runOcr(file, selectedMode)
 
-        // 2. OCR結果からテキストと extracted を取り出す
-        const withText: OcrWithText = ocr
-        const shallowFromOcr: OcrResultShallow = ocr as OcrResultShallow
+        // 2. OCR結果からテキストと extracted / image を取り出す
+        const withText: OcrWithText & { image?: OcrImage } = ocr as OcrWithText & {
+          image?: OcrImage
+        }
+        const shallowFromOcr: OcrResultShallow & { image?: OcrImage } =
+          ocr as OcrResultShallow & { image?: OcrImage }
 
         const rawOcrText = withText.rawOcrText ?? withText.text ?? ""
+
+        // /api/ocr のレスポンスの image を Import 用に整形
+        const imageForImport =
+          withText.image?.url != null
+            ? {
+                url: withText.image.url,
+                mimeType: withText.image.mimeType ?? file.type ?? "image/png",
+                width: withText.image.width ?? undefined,
+                height: withText.image.height ?? undefined,
+                sha256: withText.image.sha256 ?? undefined,
+                page: withText.image.page ?? 1,
+              }
+            : undefined
+
+        console.log("[ScanContent] imageForImport:", imageForImport)
 
         // 3. /api/receipts/import に POST（ドラフトとして保存）
         const res = await fetch("/api/receipts/import", {
@@ -135,8 +164,9 @@ export function ScanContent() {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             rawOcrText,
-            extracted: shallowFromOcr.extracted, // ★ OCR側で計算したサマリを渡す
-            // 必要があればここで files, ocrEngine, parser なども渡す
+            extracted: shallowFromOcr.extracted, // OCR 側で計算したサマリ
+            image: imageForImport, // ★ ここで /api/ocr の image をそのまま渡す
+            // 必要に応じて ocrEngine, parser なども追加可能
           }),
         })
 
@@ -186,8 +216,6 @@ export function ScanContent() {
     const summary = extractSummary(ocrResult)
     const receiptId = extractReceiptId(ocrResult)
 
-    // CompletionView は receiptId と summary を受け取り、
-    // ユーザーが「詳細を確認」押下時に /receipts/[id]/edit へ遷移する想定
     return <CompletionView receiptId={receiptId} summary={summary} onStartOver={handleStartOver} />
   }
 

--- a/src/components/scan/types.ts
+++ b/src/components/scan/types.ts
@@ -1,22 +1,82 @@
 // src/components/scan/types.ts
-export type OcrMode = "document" | "receipt" | "invoice"
+
+// OCR モード
+// ※ API 側は "text" も返しているので、ここにも含めておく
+export type OcrMode = "text" | "document" | "receipt" | "invoice"
+
+// --- 正規化後に最低限ほしいフィールドたち ---
 
 export type MinimalTotals = { grandTotal?: number | string | null }
 export type MinimalMerchant = { name?: string | null }
+
 export type MinimalNormalized = {
   merchant?: MinimalMerchant | null
   purchasedAt?: string | null
   totals?: MinimalTotals | null
 }
 
-// OCR API のレスポンス（元々の OcrResponse に合わせて調整）
-export type OcrResponse = {
-  id: string
-  mode: OcrMode
+// --- /api/ocr の抽出サマリ（storeName / purchaseDate / total / tax） ---
+
+export type OcrExtractedSummary = {
+  storeName?: string | null
+  purchaseDate?: string | null
+  total?: number | null
+  tax?: number | null
+}
+
+// --- /api/ocr の blocks 情報（単純化した形） ---
+
+export type OcrBlock = {
+  // boundingBox の各頂点
+  bbox: { x: number; y: number }[]
+  // そのブロック中のテキスト
   text: string
-  // 他にもあればここに
+}
+
+// --- /api/ocr の image 情報（Supabase Storage 上の画像） ---
+
+export type OcrImageInfo = {
+  // Supabase Storage のパス (例: "userId/timestamp.png")
+  path: string
+  // public URL (例: https://...supabase.co/storage/v1/object/public/receipts/...)
+  url: string
+
+  // 以下はあれば使うメタ情報（/api/receipts/import の ImportImage と揃えておく）
+  mimeType?: string
+  width?: number
+  height?: number
+  sha256?: string
+  page?: number
+}
+
+// --- OCR API のレスポンス（/api/ocr の JSON に合わせた型） ---
+
+export type OcrResponse = {
+  // クライアント側で付与している一時 ID（scan 内での識別用）
+  id: string
+
+  mode: OcrMode
+
+  // Vision API の全文テキスト
+  text: string
+
+  // 信頼度（0–100, /api/ocr の estimateConfidence）
+  confidence?: number
+
+  // ブロック情報（/api/ocr で組み立てている { bbox, text } の配列）
+  blocks?: OcrBlock[]
+
+  // 1枚のレシートから抜き出した店名・日付・合計・税など
+  extracted?: OcrExtractedSummary
+
+  // 既存の正規化結果（parseOcrToReceipt 由来の薄い情報）
   normalized?: MinimalNormalized | null
+
+  // 旧フィールドとの互換用（あれば）
   receipt?: MinimalNormalized | null
+
+  // Supabase Storage に保存した画像の情報
+  image?: OcrImageInfo
 }
 
 // Completion / Processing 間で使う薄い型

--- a/src/components/scan/upload-view.tsx
+++ b/src/components/scan/upload-view.tsx
@@ -3,6 +3,7 @@
 
 import type React from "react"
 import { useState, useRef, useCallback } from "react"
+import imageCompression from "browser-image-compression"
 import { Upload, Camera, ImageIcon, AlertCircle, FileText } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Alert, AlertDescription } from "@/components/ui/alert"
@@ -18,8 +19,11 @@ export interface UploadViewProps {
   onFileSelect: (file: File, selectedMode: OcrMode) => void | Promise<void>
 }
 
-const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB
+const MAX_FILE_SIZE = 10 * 1024 * 1024 // 10MB（最終的にこれ以下にしたい）
 const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/jpg", "application/pdf"]
+
+// 2MB を超える画像はアップロード前に圧縮
+const COMPRESSION_THRESHOLD = 2 * 1024 * 1024 // 2MB
 
 // 任意: モード名の表示ラベル（存在しないキーはフォールバック）
 const modeLabelMap: Partial<Record<OcrMode, string>> = {
@@ -38,47 +42,115 @@ export function UploadView({ defaultMode, modes, onFileSelect }: UploadViewProps
   const [mode, setMode] = useState<OcrMode>(defaultMode)
   const [isDragging, setIsDragging] = useState(false)
   const [error, setError] = useState("")
+  const [compressionLog, setCompressionLog] = useState<{ before: number; after: number } | null>(
+    null,
+  )
   const fileInputRef = useRef<HTMLInputElement>(null)
   const cameraInputRef = useRef<HTMLInputElement>(null)
 
-  const validateFile = useCallback((file: File): boolean => {
+  // タイプだけ先にチェック（サイズは圧縮後にチェックする）
+  const validateFileType = useCallback((file: File): boolean => {
     if (!ACCEPTED_TYPES.includes(file.type)) {
       setError("JPG、PNG、PDF形式のファイルのみ対応しています")
-      return false
-    }
-    if (file.size > MAX_FILE_SIZE) {
-      setError("ファイルサイズは10MB以下にしてください")
       return false
     }
     return true
   }, [])
 
-  const handleSelected = useCallback(
-    (file: File) => {
-      if (!validateFile(file)) return
-      setError("")
-      void onFileSelect(file, mode)
+  // 必要に応じて画像を圧縮（PDF はそのまま）
+  const compressImageIfNeeded = useCallback(
+    async (file: File): Promise<File> => {
+      // 画像以外（PDFなど）は圧縮しない
+      if (!file.type.startsWith("image/")) {
+        setCompressionLog(null)
+        return file
+      }
+
+      // 2MB 以下ならそのまま
+      if (file.size <= COMPRESSION_THRESHOLD) {
+        setCompressionLog(null)
+        return file
+      }
+
+      try {
+        const compressedBlob = await imageCompression(file, {
+          maxSizeMB: 2, // 上限 2MB を目安に圧縮
+          maxWidthOrHeight: 2000, // 長辺 2000px くらいに制限
+          useWebWorker: true,
+        })
+
+        const compressedFile = new File([compressedBlob], file.name, {
+          type: compressedBlob.type || file.type,
+          lastModified: Date.now(),
+        })
+
+        console.log(
+          "[UploadView] compressed:",
+          `${(file.size / 1024 / 1024).toFixed(2)}MB -> ${(compressedFile.size / 1024 / 1024).toFixed(2)}MB`,
+        )
+
+        setCompressionLog({
+          before: file.size,
+          after: compressedFile.size,
+        })
+
+        return compressedFile
+      } catch (err) {
+        console.error("[UploadView] image compression failed, use original file", err)
+        // 圧縮に失敗した場合は元のファイルをそのまま使う
+        setCompressionLog(null)
+        return file
+      }
     },
-    [mode, onFileSelect, validateFile],
+    [],
+  )
+
+  const handleSelected = useCallback(
+    async (file: File) => {
+      // 1. タイプチェック
+      if (!validateFileType(file)) return
+
+      setError("")
+
+      // 2. 画像ならアップロード前に圧縮
+      const finalFile = await compressImageIfNeeded(file)
+
+      // 3. 圧縮後のサイズをチェック（サーバー側の制限と合わせる）
+      if (finalFile.size > MAX_FILE_SIZE) {
+        setError("ファイルサイズは10MB以下にしてください")
+        return
+      }
+
+      // 4. 親コンポーネントへ渡す
+      void onFileSelect(finalFile, mode)
+    },
+    [compressImageIfNeeded, mode, onFileSelect, validateFileType],
   )
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
-    if (file) handleSelected(file)
+    if (file) {
+      void handleSelected(file)
+      // 同じファイルを再選択できるようにリセット
+      e.target.value = ""
+    }
   }
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault()
     setIsDragging(false)
     const file = e.dataTransfer.files?.[0]
-    if (file) handleSelected(file)
+    if (file) void handleSelected(file)
   }
 
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault()
     setIsDragging(true)
   }
+
   const handleDragLeave = () => setIsDragging(false)
+
+  const formatMB = (bytes: number) => (bytes / 1024 / 1024).toFixed(2)
 
   return (
     <div className="flex min-h-[calc(100vh-5rem)] items-center justify-center p-4">
@@ -123,6 +195,18 @@ export function UploadView({ defaultMode, modes, onFileSelect }: UploadViewProps
           <Alert variant="destructive">
             <AlertCircle className="h-4 w-4" />
             <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        {/* 圧縮ログ表示 */}
+        {compressionLog && !error && (
+          <Alert variant="default" className="border-blue-200 bg-blue-50/70">
+            <AlertDescription className="text-sm text-slate-700">
+              画像を圧縮しました：
+              <span className="ml-1 font-mono">
+                {formatMB(compressionLog.before)}MB → {formatMB(compressionLog.after)}MB
+              </span>
+            </AlertDescription>
           </Alert>
         )}
 

--- a/src/lib/ocr.ts
+++ b/src/lib/ocr.ts
@@ -1,6 +1,144 @@
-import type { OcrMode, OcrResponse } from "@/components/scan/types"
+// src/lib/ocr.ts
+import type {
+  OcrMode,
+  OcrResponse,
+  OcrBlock,
+  OcrExtractedSummary,
+  MinimalNormalized,
+  OcrImageInfo,
+} from "@/components/scan/types"
 
-export async function runOcr(file: File, mode: OcrMode = "document"): Promise<OcrResponse> {
+type RawOcrJson = {
+  mode?: string
+  text?: string
+  confidence?: number
+  blocks?: unknown
+  extracted?: unknown
+  normalized?: unknown
+  receipt?: unknown
+  image?: unknown
+}
+
+function safeExtracted(extracted: unknown): OcrExtractedSummary | undefined {
+  if (!extracted || typeof extracted !== "object") return undefined
+  const obj = extracted as {
+    storeName?: unknown
+    purchaseDate?: unknown
+    total?: unknown
+    tax?: unknown
+  }
+
+  return {
+    storeName:
+      typeof obj.storeName === "string" || obj.storeName == null
+        ? (obj.storeName ?? null)
+        : null,
+    purchaseDate:
+      typeof obj.purchaseDate === "string" || obj.purchaseDate == null
+        ? (obj.purchaseDate ?? null)
+        : null,
+    total: typeof obj.total === "number" || obj.total == null ? (obj.total ?? null) : null,
+    tax: typeof obj.tax === "number" || obj.tax == null ? (obj.tax ?? null) : null,
+  }
+}
+
+function safeMinimalNormalized(src: unknown): MinimalNormalized | null {
+  if (!src || typeof src !== "object") return null
+
+  const obj = src as {
+    merchant?: { name?: unknown } | null
+    purchasedAt?: unknown
+    totals?: { grandTotal?: unknown } | null
+  }
+
+  const merchant =
+    obj.merchant && typeof obj.merchant === "object"
+      ? {
+          name:
+            typeof obj.merchant.name === "string" || obj.merchant.name == null
+              ? (obj.merchant.name ?? null)
+              : null,
+        }
+      : undefined
+
+  const purchasedAt =
+    typeof obj.purchasedAt === "string" || obj.purchasedAt == null
+      ? (obj.purchasedAt ?? null)
+      : null
+
+  const totals =
+    obj.totals && typeof obj.totals === "object"
+      ? {
+          grandTotal:
+            typeof obj.totals.grandTotal === "number" ||
+            typeof obj.totals.grandTotal === "string" ||
+            obj.totals.grandTotal == null
+              ? (obj.totals.grandTotal ?? null)
+              : null,
+        }
+      : undefined
+
+  return { merchant, purchasedAt, totals }
+}
+
+function safeBlocks(rawBlocks: unknown): OcrBlock[] | undefined {
+  if (!Array.isArray(rawBlocks)) return undefined
+
+  const blocks: OcrBlock[] = rawBlocks
+    .map((b): OcrBlock | null => {
+      if (!b || typeof b !== "object") return null
+
+      const anyBlock = b as { bbox?: unknown; text?: unknown }
+
+      const rawBbox = Array.isArray(anyBlock.bbox) ? anyBlock.bbox : []
+      const bbox = rawBbox
+        .map((v): { x: number; y: number } | null => {
+          if (!v || typeof v !== "object") return null
+          const anyV = v as { x?: unknown; y?: unknown }
+          const x = typeof anyV.x === "number" ? anyV.x : 0
+          const y = typeof anyV.y === "number" ? anyV.y : 0
+          return { x, y }
+        })
+        .filter((v): v is { x: number; y: number } => v !== null)
+
+      const text = typeof anyBlock.text === "string" ? anyBlock.text : ""
+
+      return { bbox, text }
+    })
+    .filter((b): b is OcrBlock => b !== null)
+
+  return blocks.length ? blocks : undefined
+}
+
+function safeImage(raw: unknown): OcrImageInfo | undefined {
+  if (!raw || typeof raw !== "object") return undefined
+  const obj = raw as {
+    path?: unknown
+    url?: unknown
+    mimeType?: unknown
+    width?: unknown
+    height?: unknown
+    sha256?: unknown
+    page?: unknown
+  }
+
+  if (typeof obj.path !== "string" || typeof obj.url !== "string") return undefined
+
+  return {
+    path: obj.path,
+    url: obj.url,
+    mimeType: typeof obj.mimeType === "string" ? obj.mimeType : undefined,
+    width: typeof obj.width === "number" ? obj.width : undefined,
+    height: typeof obj.height === "number" ? obj.height : undefined,
+    sha256: typeof obj.sha256 === "string" ? obj.sha256 : undefined,
+    page: typeof obj.page === "number" ? obj.page : undefined,
+  }
+}
+
+export async function runOcr(
+  file: File,
+  mode: OcrMode = "document",
+): Promise<OcrResponse> {
   const fd = new FormData()
   fd.append("file", file)
 
@@ -9,10 +147,50 @@ export async function runOcr(file: File, mode: OcrMode = "document"): Promise<Oc
     body: fd,
   })
 
-  const json = await res.json()
-  if (!res.ok) {
-    const reason = json?.error || "OCR failed"
-    throw new Error(reason)
+  let json: unknown
+  try {
+    json = await res.json()
+  } catch {
+    throw new Error("OCR API のレスポンスのパースに失敗しました")
   }
-  return json as OcrResponse
+
+  // --- エラーレスポンス処理 ---
+  if (!res.ok) {
+    const err =
+      typeof json === "object" &&
+      json !== null &&
+      "error" in json &&
+      typeof (json as { error?: unknown }).error === "string"
+        ? (json as { error?: string }).error
+        : undefined
+
+    throw new Error(err || `OCR failed (${res.status})`)
+  }
+
+  const data = json as RawOcrJson
+
+  const id =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID()
+      : `${Date.now()}-${Math.random().toString(16).slice(2)}`
+
+  const minimal =
+    safeMinimalNormalized(data.normalized) ??
+    safeMinimalNormalized(data.receipt) ??
+    null
+
+  const response: OcrResponse = {
+    id,
+    mode: (data.mode ?? mode) as OcrMode,
+    text: data.text ?? "",
+    confidence:
+      typeof data.confidence === "number" ? data.confidence : undefined,
+    blocks: safeBlocks(data.blocks),
+    extracted: safeExtracted(data.extracted),
+    normalized: minimal,
+    receipt: minimal,
+    image: safeImage(data.image),
+  }
+
+  return response
 }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,6 +1,6 @@
 // src/lib/supabase/server.ts
 import { createServerClient, type CookieOptions } from "@supabase/ssr"
-import type { SupabaseClient } from "@supabase/supabase-js"
+import { createClient, type SupabaseClient } from "@supabase/supabase-js"
 
 /**
  * Next の cookies() が Sync/Async どちらでも動くように吸収するヘルパ
@@ -23,13 +23,21 @@ async function getCookieStore() {
   }
 }
 
-/** 読み取り専用（Server Component など・cookie 書き込みは no-op） */
-export async function createSupabaseServerClientReadonly(): Promise<SupabaseClient> {
+/**
+ * 共通の URL/KEY チェック
+ */
+function getSupabaseAnonEnv() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-  if (!url || !key)
+  if (!url || !key) {
     throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY")
+  }
+  return { url, key }
+}
 
+/** 読み取り専用（Server Component など・cookie 書き込みは no-op） */
+export async function createSupabaseServerClientReadonly(): Promise<SupabaseClient> {
+  const { url, key } = getSupabaseAnonEnv()
   const cookieStore = await getCookieStore()
 
   return createServerClient(url, key, {
@@ -49,11 +57,7 @@ export async function createSupabaseServerClientReadonly(): Promise<SupabaseClie
 
 /** Route Handler 等で cookie の set/remove が必要な場合はこちらを使用 */
 export async function createSupabaseServerClientMutable(): Promise<SupabaseClient> {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
-  if (!url || !key)
-    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY")
-
+  const { url, key } = getSupabaseAnonEnv()
   const cookieStore = await getCookieStore()
 
   return createServerClient(url, key, {
@@ -75,6 +79,26 @@ export async function createSupabaseServerClientMutable(): Promise<SupabaseClien
           // 同上
         }
       },
+    },
+  })
+}
+
+/**
+ * サービスロールキーを使った完全サーバー専用クライアント
+ * - cookies には依存しない
+ * - RLS をバイパスするため、**絶対にクライアント側には渡さないこと**
+ * - 画像保存のバッチ処理など、将来的な用途向け
+ */
+export function createSupabaseServiceClient(): SupabaseClient {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  if (!url || !serviceKey) {
+    throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY")
+  }
+
+  return createClient(url, serviceKey, {
+    auth: {
+      persistSession: false,
     },
   })
 }

--- a/src/server/receipts/persist.ts
+++ b/src/server/receipts/persist.ts
@@ -15,6 +15,7 @@ export type PersistInput = {
     width?: number
     height?: number
     sha256?: string
+    page?: number // ★ 追加：OCR 側で page 情報を持たせたい場合に対応
   }>
   ocrEngine?: "TESSERACT" | "GOOGLE_DOC_AI" | "AWS_TEXTRACT" | "AZURE_FORM_RECOGNIZER" | "OTHER"
   parser?: string
@@ -23,6 +24,9 @@ export type PersistInput = {
 
   // 呼び出し側から保存時のステータスを指定できる（DRAFT / READY / ERROR など）
   status?: Prisma.ReceiptCreateInput["status"]
+
+  // ★ 追加：代表画像として Receipt.imageUrl に入れたい URL
+  imageUrl?: string | null
 }
 
 /** テキストベース重複指紋（画像指紋と併用推奨） */
@@ -42,6 +46,7 @@ export async function persistReceipt(input: PersistInput) {
     parseVersion,
     taxBreakdown,
     status = "DRAFT", // 呼び出し側から指定がなければ DRAFT
+    imageUrl, // ★ 追加
   } = input
 
   const fp = textFingerprint(rawOcrText)
@@ -49,7 +54,7 @@ export async function persistReceipt(input: PersistInput) {
   // 既存重複チェック（user単位）
   const dup = await prisma.receipt.findFirst({
     where: { userId, fingerprint: fp },
-    select: { id: true, status: true },
+    select: { id: true, status: true, imageUrl: true },
   })
 
   // ========== 既存レシートがある場合はそれを再利用 ==========
@@ -64,6 +69,9 @@ export async function persistReceipt(input: PersistInput) {
       data: {
         // 重複扱いにしたい場合
         status: "DUPLICATE",
+
+        // もし新しい imageUrl が来ていて、まだ imageUrl が空なら更新しておく（任意ロジック）
+        imageUrl: dup.imageUrl ?? imageUrl ?? null,
 
         // 解析メタは最新で上書きしておく
         rawOcrText,
@@ -143,6 +151,12 @@ export async function persistReceipt(input: PersistInput) {
       memo: null,
       status: effectiveStatus,
 
+      // ★ ここで imageUrl を保存する
+      //   1. 呼び出し側から明示的に渡された imageUrl
+      //   2. なければ files[0].url
+      //   3. どちらもなければ null
+      imageUrl: imageUrl ?? (files[0]?.url ?? null),
+
       // 解析メタ
       rawOcrText,
       normalizedJson: JSON.parse(JSON.stringify(base)) as Prisma.InputJsonValue,
@@ -165,7 +179,8 @@ export async function persistReceipt(input: PersistInput) {
       files: files.length
         ? {
             create: files.map((f, idx) => ({
-              page: idx + 1,
+              // ★ Import 側で page が来ていれば優先し、なければ 1,2,3... を採用
+              page: f.page ?? idx + 1,
               url: f.url,
               mimeType: f.mimeType ?? undefined,
               width: f.width ?? undefined,

--- a/src/types/receipt.ts
+++ b/src/types/receipt.ts
@@ -15,6 +15,20 @@ export interface ReceiptItem {
   amount: number
 }
 
+// Storage に保存されたレシート画像 1 件分
+export interface ReceiptFile {
+  id: string
+  receiptId: string
+  page: number | null
+  url: string
+  mimeType: string | null
+  width: number | null
+  height: number | null
+  sha256: string | null
+  createdAt: string
+  updatedAt: string
+}
+
 export interface Receipt {
   id: string
   userId: string
@@ -48,11 +62,14 @@ export interface Receipt {
   // OCR の信頼度（0〜1）
   confidenceScore?: number
 
-  // 元画像の URL（ある場合のみ）
+  // 既存の単一画像 URL（必要ならそのまま併用）
   imageUrl?: string
 
   // 品目一覧
   items: ReceiptItem[]
+
+  // 添付ファイル一覧（Supabase Storage の画像など）
+  files?: ReceiptFile[]
 
   // カテゴリ ID（任意）
   categoryId?: string


### PR DESCRIPTION
## 概要

レシートOCRでアップロードした画像を Supabase Storage に保存し、
その画像をレシート詳細画面でプレビュー表示できるようにしました。

また、レシート削除時に関連する ReceiptFile レコードと
Supabase Storage 上の画像も合わせて削除するようにしています。

対象 Issue: #14

---

## 変更内容

### 1. OCR → Supabase Storage への画像保存

- `/api/ocr`
  - 画像を Sharp で前処理（回転補正・グレースケール・リサイズ・PNG化）
  - Supabase Storage の `receipts` バケットに `{supabaseUser.id}/{timestamp}.png` で保存
  - `getPublicUrl` で公開 URL を取得し、レスポンスの `image` に `{ path, url }` を追加
- `src/lib/supabase/server.ts`
  - Storage 操作用のサーバークライアントを利用（サービスロール）
- `persistReceipt`
  - `files` 引数を受け取り、`ReceiptFile` に `url / mimeType / size など` を保存
  - 既存のテキスト重複検知（fingerprint）はそのまま利用

### 2. OCR スキャンフローとフロント側の画像プレビュー

- `ScanContent`
  - `/api/ocr` のレスポンスから `image` を取り出し、
    `/api/receipts/import` に `image.url` を含めて POST
  - 正規化したサマリ情報（storeName / purchaseDate / total）を渡してドラフト保存
- `/api/receipts/import`
  - `files` がなければ `image` から `files` を1件生成して `persistReceipt` に渡すように変更
- `/api/receipts/[id]`
  - `ReceiptFile` を include し、`files[0].url` を優先的に `imageUrl` として返却
- `ReceiptImagePreview`
  - 受け取った `imageUrl` を利用してレシート画像を表示
  - 拡大縮小（0.5〜3.0）と 90° 回転ボタンを追加
- `receipt-detail-content.tsx`（詳細パネル）
  - 右側に画像プレビューを表示
  - `files[0].url` or `imageUrl` を渡すように修正

### 3. レシート削除時の Supabase Storage クリーンアップ

- `DELETE /api/receipts/[id]`
  - レシートに紐づく `ReceiptFile` を取得し、その `url` からストレージ内パスを特定
  - Supabase Storage の `receipts` バケットから該当ファイルを削除
  - Prisma のトランザクションで
    - `receipt_items` / `receipt_files` / `receipts` を削除（または `deletedAt` をセット）
  - 画像削除に失敗した場合はログ出力しつつ、少なくとも DB 側は一貫した状態になるように実装

---

## 動作確認

ローカル環境（`feature/issue14-receipt-image-save-and-optimize` ブランチ）で以下を確認しました。

- [x] `/scan` 画面からレシート画像をアップロードすると、
      `/api/ocr` が実行され、Supabase Storage `receipts` バケットに画像が保存される
- [x] OCR 完了後、自動で `/api/receipts/import` が呼ばれ、
      `Receipt` + `ReceiptFile` が DB に作成される
- [x] レシート一覧から対象レシートを開くと、
      右側のプレビューにアップロードした画像が表示される
- [x] プレビュー画面で拡大・縮小・回転が期待通りに動作する
- [x] レシートを削除した際に、
      - DB の `receipt_files` レコードが削除されていること
      - Supabase Storage から対応するファイルが削除されていること
      を手動で確認済み

---

## 影響範囲・互換性

- 既存のレシートデータ：
  - `imageUrl` が null でも、`files` が存在しない場合は UI 側で「画像がありません」と表示されるだけなので、
    既存レコードへの影響はありません。
- DB スキーマ：
  - この PR では Prisma Schema の変更は行っておらず、
    既に定義済みの `ReceiptFile` モデルを利用しています。
- 外部サービス：
  - Supabase Storage の `receipts` バケットが存在していることが前提です。
  - 本番環境にデプロイする際は、同名バケットが作成済みか確認が必要です。

---

## 補足・気になる点

- 現状、画像の公開 URL は `getPublicUrl` を利用し、
  認証なしでアクセス可能な URL を利用しています。
  将来的に「非公開ストレージ + サインドURL」を使うポリシーに変更する場合は、
  この部分の実装を差し替える想定です。
- レシート削除時に Storage 側の削除が失敗した場合、
  DB 上の削除は優先しつつ、ログで検知できるようにしています。
