### PR TITLE
🚑 Fix: Vercel 本番環境で Prisma Client が生成されず API が落ちる問題 (#18)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ temp/
 headers.txt
 jar.txt
 before.jar
+
+/prisma/generated/
+/node_modules/.prisma/

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "my-v0-project",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@google-cloud/vision": "latest",
         "@hookform/resolvers": "latest",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky",
+    "postinstall": "prisma generate",
     "setup:ocr": "mkdir -p public/tessdata && curl -L -o public/tessdata/eng.traineddata https://github.com/tesseract-ocr/tessdata_best/raw/main/eng.traineddata && curl -L -o public/tessdata/jpn.traineddata https://github.com/tesseract-ocr/tessdata_best/raw/main/jpn.traineddata"
   },
   "dependencies": {


### PR DESCRIPTION
# 🚑 Fix: Vercel 本番環境で Prisma Client が生成されず API が落ちる問題 (#18)

## 🔧 概要（What / Why）

Vercel デプロイ時に以下のエラーが発生し、本番環境で API Routes（特に `/api/receipts/[id]`）がビルドに失敗していました。

@prisma/client did not initialize yet. Please run "prisma generate"


原因は、Vercel のビルド環境において **`prisma generate` が自動実行されない** ため、Prisma Client が生成されず import 時に例外が発生していたことです。

そのため、依存関係インストール時に Prisma Client が常に生成されるように修正しました。

---

## 🔨 変更内容（Changes）

この PR では、以下 3 点の修正を行っています。

### 1. `postinstall` に `prisma generate` を追加  
（commit: `4d096b8`）

Vercel などの本番ビルド環境で Prisma Client が必ず生成されるようにしました。

```json
"scripts": {
  "postinstall": "prisma generate"
}
```

### 2. next-env.d.ts の更新
（commit: 99beacd）
依存関係更新によって Next.js が再生成した型宣言ファイルを反映しました。
アプリの挙動には影響ありませんが、型整合性を保つためにコミットしています。

### 3. .gitignore の調整
（commit: 1efdf07）
Prisma キャッシュやビルド生成物など、不要なファイルが Git 管理に入らないよう .gitignore を整理しました

## ✔️ 受け入れ条件（Acceptance Criteria）
 - [ ] Vercel のビルドが成功する
  - [ ] 本番 API (/api/receipts/[id] など) が 500 エラーを出さず動作する
  - [ ] Prisma Client が必ず生成された状態で本番動作する
  - [ ] ローカル環境の開発フローに影響がない

##  🧪 動作確認（How to Test）
### ローカル確認
```bash
npm install
npm run build
npm start
```

### 確認ポイント
- Prisma Client が生成されている（node_modules/.prisma/client が存在）
- API Routes が正常にレスポンスを返す
- ローカルでビルドエラーが発生しない

### Vercel Preview 確認
- デプロイがエラーなく完了
- /api/receipts/[id] が 200 で動作する
- Prisma Client 未生成エラーが出ない

## 📎 関連 Issue
Closes #18