### PR TITLE
📌 店舗名が品名として抽出される問題の修正

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/api/receipts/import/route.ts
+++ b/src/app/api/receipts/import/route.ts
@@ -265,11 +265,22 @@ function scoreItemName(line: string): number {
 function isItemNameCandidate(line: string): boolean {
   const s = line.trim()
   if (!s) return false
+
+  // 金額・小計・合計などは除外
   if (/(小計|合計|総合計|税|円|JPY|領収書|お買上明細)/.test(s)) return false
   if (isPriceLine(s)) return false
+
+  // ★ 店舗名っぽい行は除外（ここを追加）
+  //   - 行末が「店」
+  //   - 会社・支店など
+  if (/(株式会社|有限会社|支店|本店|支社|営業所|店$)/.test(s)) return false
+
+  // 文字種チェック
   if (!/[A-Za-z一-龠々ァ-ヶーぁ-ん]/.test(s)) return false
+
   return scoreItemName(s) > 0
 }
+
 
 function extractItemsFromText(rawText: string, grandTotal?: number): ParsedItem[] {
   const lines = rawText
@@ -369,7 +380,7 @@ function extractItemsFromText(rawText: string, grandTotal?: number): ParsedItem[
 
   // 1件も取れなかった場合のみ、合計金額 1 行だけのフォールバック
   if (!items.length && grandTotal != null && grandTotal > 0) {
-    const fallbackName = zone.find((l) => isItemNameCandidate(l)) || "不明な品目"
+    const fallbackName =  [...zone].reverse().find((l) => isItemNameCandidate(l)) || "不明な品目"
 
     items.push({
       name: fallbackName,


### PR DESCRIPTION
# 📌 店舗名が品名として抽出される問題の修正
## 📝 概要

OCR の品目抽出ロジックにおいて、
店舗名（例：「京阪京橋駅片町口店」）が品名として誤って登録されてしまう問題を修正しました。

スターバックスやコンビニなど、多くのレシートで店舗名が品名候補として扱われ、
金額行と紐づくことで誤検出されているケースが発生していたため、
品名判定ロジックの改善を行っています。
---

## 🔧 修正内容
### 1. 店舗名を品名候補から明確に除外

isItemNameCandidate に店舗名フィルタを追加し、以下を含む行を品目候補扱いしないように変更。

- 行末が「店」で終わる
- 「支店」「本店」「支社」「営業所」
- 「株式会社」「有限会社」
- その他、店舗名で典型的に使われる表現

これにより、店舗名が誤って品名として採用される問題を解消。

### 2. フォールバック品名探索の改善（必要に応じて適用）

品目抽出に失敗した場合、品名候補を「上から」ではなく
「下から（明細寄り）優先して」探索する処理に変更し、
店舗情報を拾いづらくする改善も行いました。

※ 実際の変更内容は diff を参照

## 🖼 再現例（問題のあったケース）
- スターバックスのレシート
- 「京阪京橋駅片町口店」などの店舗名が、
金額行（例：414）の直前に存在することで誤って品名判定される

今回の修正により、これらのケースで品名として扱われなくなりました。

## ✔ 動作確認
- [x] スターバックスのレシートで店舗名が品名に設定されない
- [x] コンビニ（セブン・ファミマ等）の店舗名も同様に除外される
- [x] 明細の品名が正しく抽出される or 抽出できない場合は「不明な品目」などのフォールバック動作になる
- [x] 既存の正常ケースに退行がないことを確認

## 🗂 関連 Issue
#20 店舗名が品名として抽出される問題の修正

## 💬 補足

今回の修正は抽出ロジックの改善であり、parseOcrToReceipt 自体の挙動には影響を与えていません。
必要に応じて、特定チェーン（スタバなど）のパターンにも最適化できますが、
まずは汎用的な改善として本 PR をマージしたいです。
